### PR TITLE
remove smooth scroll jquery script tag

### DIFF
--- a/public/splash/index.html
+++ b/public/splash/index.html
@@ -197,7 +197,6 @@
   <!-- Scripts -->
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrollex.min.js"></script>
-  <!-- <script src="assets/js/jquery.scrolly.min.js"></script> -->
   <script src="assets/js/browser.min.js"></script>
   <script src="assets/js/breakpoints.min.js"></script>
   <script src="assets/js/util.js"></script>


### PR DESCRIPTION
Possible fix for weird scrolling bug when using the nav bar links.

I had this bug when CSS `smooth-scroll` and JQuery's smooth scroll were colliding. It worked fine locally when I commented that script tag out but the bug is back on our live version so I just removed it completely in hopes that will fix it.